### PR TITLE
Corrected non-portable reuse of va_list in dt_printf()

### DIFF
--- a/cddl/contrib/opensolaris/lib/libdtrace/common/dt_subr.c
+++ b/cddl/contrib/opensolaris/lib/libdtrace/common/dt_subr.c
@@ -581,6 +581,7 @@ int
 dt_printf(dtrace_hdl_t *dtp, FILE *fp, const char *format, ...)
 {
 	va_list ap;
+	va_list ap2;
 	int n;
 
 #ifndef illumos
@@ -640,11 +641,14 @@ dt_printf(dtrace_hdl_t *dtp, FILE *fp, const char *format, ...)
 			dtp->dt_buffered_buf[0] = '\0';
 		}
 
-		if ((needed = vsnprintf(NULL, 0, format, ap)) < 0) {
+		va_copy(ap2, ap);
+		if ((needed = vsnprintf(NULL, 0, format, ap2)) < 0) {
 			rval = dt_set_errno(dtp, errno);
+			va_end(ap2);
 			va_end(ap);
 			return (rval);
 		}
+		va_end(ap2);
 
 		if (needed == 0) {
 			va_end(ap);


### PR DESCRIPTION
va_list on x86-64 needs to be a more complex type than a single pointer to the stack, for example because some arguments may be passed as registers. As a result reusing a va_list without performing a va_copy is non-portable across platforms.

I've attempted to minimize changes to the original structure by taking a copy of the va_list (with va_copy) when it is needed and then calling va_end() as soon as it is no longer needed. I've checked the rest of the code (libdtrace, dtrace command and driver) for any further uses of this pattern.