### PR TITLE
Dtrace gnn mbufcopy

### DIFF
--- a/cddl/contrib/opensolaris/lib/libdtrace/common/dt_open.c
+++ b/cddl/contrib/opensolaris/lib/libdtrace/common/dt_open.c
@@ -242,6 +242,8 @@ static const dt_ident_t _dtrace_globals[] = {
 { "copyoutstr", DT_IDENT_FUNC, 0, DIF_SUBR_COPYOUTSTR,
 	DT_ATTR_STABCMN, DT_VERS_1_0,
 	&dt_idops_func, "void(char *, uintptr_t, size_t)" },
+{ "copyoutmbuf", DT_IDENT_FUNC, 0, DIF_SUBR_COPYOUTMBUF, DT_ATTR_STABCMN, DT_VERS_1_0,
+	&dt_idops_func, "void*(struct mbuf *, size_t)" },
 { "count", DT_IDENT_AGGFUNC, 0, DTRACEAGG_COUNT, DT_ATTR_STABCMN, DT_VERS_1_0,
 	&dt_idops_func, "void()" },
 { "curthread", DT_IDENT_SCALAR, 0, DIF_VAR_CURTHREAD,

--- a/sys/cddl/contrib/opensolaris/uts/common/sys/dtrace.h
+++ b/sys/cddl/contrib/opensolaris/uts/common/sys/dtrace.h
@@ -318,8 +318,9 @@ typedef enum dtrace_probespec {
 #define	DIF_SUBR_STRTOLL		54
 #define	DIF_SUBR_RANDOM			55
 #define	DIF_SUBR_UUIDTOSTR		56
+#define DIF_SUBR_COPYOUTMBUF		57
 
-#define	DIF_SUBR_MAX			56	/* max subroutine value */
+#define	DIF_SUBR_MAX			57	/* max subroutine value */
 
 typedef uint32_t dif_instr_t;
 


### PR DESCRIPTION
A new subroutine, copyoutmbuf() which returns all the data in an mbuf chain to the caller, with appropriate safety checks.