### PR TITLE
Audit events preload

### DIFF
--- a/stand/forth/loader.conf
+++ b/stand/forth/loader.conf
@@ -554,6 +554,13 @@ mac_none_load="NO"		# Null MAC policy
 mac_partition_load="NO"		# Partition MAC policy
 mac_seeotheruids_load="NO"	# UID visbility MAC policy
 
+##############################################################
+###  Audit settings  #########################################
+##############################################################
+
+audit_event_load="NO"		# Preload audit_event config
+audit_event_name="/etc/security/audit_event"
+audit_event_type="etc_security_audit_event"
 
 ##############################################################
 ###  Module loading syntax example  ##########################

--- a/sys/security/audit/audit_bsm_db.c
+++ b/sys/security/audit/audit_bsm_db.c
@@ -264,7 +264,7 @@ au_evnamemap_insert(au_event_t event, const char *name)
 }
 
 /*
- * If /etc/security/audit_events has been preloaded by the boot loader, parse
+ * If /etc/security/audit_event has been preloaded by the boot loader, parse
  * it to build an initial set of event number<->name mappings.
  */
 static void
@@ -296,7 +296,6 @@ au_evnamemap_init_preload(void)
 	 */
 	nextline = ptr;
 	lineno = 0;
-	printf("%s: Starting\n", __func__);
 	while ((line = strsep(&nextline, "\n")) != NULL) {
 		/*
 		 * Skip blank lines and comment lines.
@@ -332,11 +331,8 @@ au_evnamemap_init_preload(void)
 			continue;
 		}
 		au_evnamemap_insert(evnum, evname);
-		printf("%s: Added line %u - %ld:%s\n", __func__, lineno,
-		    evnum, evname);
 		lineno++;
 	}
-	printf("%s: Done\n", __func__);
 }
 
 void

--- a/sys/security/audit/audit_bsm_db.c
+++ b/sys/security/audit/audit_bsm_db.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 1999-2009 Apple Inc.
- * Copyright (c) 2005, 2016-2017 Robert N. M. Watson
+ * Copyright (c) 2005, 2016-2018 Robert N. M. Watson
  * All rights reserved.
  *
  * Portions of this software were developed by BAE Systems, the University of
@@ -41,6 +41,7 @@ __FBSDID("$FreeBSD$");
 #include <sys/fcntl.h>
 #include <sys/filedesc.h>
 #include <sys/libkern.h>
+#include <sys/linker.h>
 #include <sys/malloc.h>
 #include <sys/mount.h>
 #include <sys/proc.h>
@@ -91,6 +92,7 @@ static struct evclass_list	evclass_hash[EVCLASSMAP_HASH_TABLE_SIZE];
  * struct evname_elem is defined in audit_private.h so that audit_dtrace.c can
  * use the definition.
  */
+#define	EVNAMEMAP_HASH_TABLE_MODULE	"etc_security_audit_event"
 #define	EVNAMEMAP_HASH_TABLE_SIZE	251
 struct evname_list {
 	LIST_HEAD(, evname_elem)	enl_head;
@@ -261,6 +263,82 @@ au_evnamemap_insert(au_event_t event, const char *name)
 	EVNAMEMAP_WUNLOCK();
 }
 
+/*
+ * If /etc/security/audit_events has been preloaded by the boot loader, parse
+ * it to build an initial set of event number<->name mappings.
+ */
+static void
+au_evnamemap_init_preload(void)
+{
+	caddr_t kmdp;
+	char *endptr, *line, *nextline, *ptr;
+	const char *evnum_str, *evname;
+	size_t size;
+	long evnum;
+	u_int lineno;
+
+	kmdp = preload_search_by_type(EVNAMEMAP_HASH_TABLE_MODULE);
+	if (kmdp == NULL)
+		return;
+	ptr = preload_fetch_addr(kmdp);
+	size = preload_fetch_size(kmdp);
+
+	/*
+	 * Assume that we can write into preloaded memory, and that because
+	 * the last character is a new line, we can replace it with a nul byte
+	 * safely.  This allows us to then use strsep(3).  Alternatively, we
+	 * could allocate memory, memcpy(), etc...
+	 */
+	ptr[size-1] = '\0';
+
+	/*
+	 * Process line by line.
+	 */
+	nextline = ptr;
+	lineno = 0;
+	printf("%s: Starting\n", __func__);
+	while ((line = strsep(&nextline, "\n")) != NULL) {
+		/*
+		 * Skip blank lines and comment lines.
+		 */
+		if (line[0] == '\0' || line[0] == '#') {
+			lineno++;
+			continue;
+		}
+
+		/*
+		 * Parse each line -- ":"-separated tuple of event number,
+		 * event name, and other material we are less interested in.
+		 */
+		evnum_str = strsep(&line, ":");
+		if (evnum_str == NULL || *evnum_str == '\0') {
+			printf("%s: Invalid line %u - evnum strsep\n",
+			    __func__, lineno);
+			lineno++;
+			continue;
+		}
+		evnum = strtol(evnum_str, &endptr, 10);
+		if (endptr == NULL || *endptr != '\0') {
+			printf("%s: Invalid line %u - evnum strtol\n",
+			    __func__, lineno);
+			lineno++;
+			continue;
+		}
+		evname = strsep(&line, ":");
+		if (evname == NULL || *evname == '\0') {
+			printf("%s: Invalid line %u - evname strsp\n",
+			    __func__, lineno);
+			lineno++;
+			continue;
+		}
+		au_evnamemap_insert(evnum, evname);
+		printf("%s: Added line %u - %ld:%s\n", __func__, lineno,
+		    evnum, evname);
+		lineno++;
+	}
+	printf("%s: Done\n", __func__);
+}
+
 void
 au_evnamemap_init(void)
 {
@@ -269,13 +347,7 @@ au_evnamemap_init(void)
 	EVNAMEMAP_LOCK_INIT();
 	for (i = 0; i < EVNAMEMAP_HASH_TABLE_SIZE; i++)
 		LIST_INIT(&evnamemap_hash[i].enl_head);
-
-	/*
-	 * XXXRW: Unlike the event-to-class mapping, we don't attempt to
-	 * pre-populate the list.  Perhaps we should...?  But not sure we
-	 * really want to duplicate /etc/security/audit_event in the kernel
-	 * -- and we'd need a way to remove names?
-	 */
+	au_evnamemap_init_preload();
 }
 
 /*

--- a/sys/security/audit/audit_bsm_db.c
+++ b/sys/security/audit/audit_bsm_db.c
@@ -298,6 +298,12 @@ au_evnamemap_init_preload(void)
 	lineno = 0;
 	while ((line = strsep(&nextline, "\n")) != NULL) {
 		/*
+		 * Skip any leading white space.
+		 */
+		while (line[0] == ' ' || line[0] == '\t')
+			line++;
+
+		/*
 		 * Skip blank lines and comment lines.
 		 */
 		if (line[0] == '\0' || line[0] == '#') {
@@ -317,7 +323,8 @@ au_evnamemap_init_preload(void)
 			continue;
 		}
 		evnum = strtol(evnum_str, &endptr, 10);
-		if (endptr == NULL || *endptr != '\0') {
+		if (*evnum_str == '\0' || *endptr != '\0' ||
+		    evnum <= 0 || evnum > UINT16_MAX) {
 			printf("%s: Invalid line %u - evnum strtol\n",
 			    __func__, lineno);
 			lineno++;


### PR DESCRIPTION
This change allows the audit subsystem to configure a set of audit event number <-> name mappings earlier in boot, using a copy of /etc/security/audit_event preloaded by the boot loader. This means that dtaudit can initialise a complete set of audit-related probes at audit initialisation time, rather than waiting until auditd(8) has started well into the multiuser boot. When auditd(8) does start, it can update the mappings. To enable this feature, put 'audit_event_load="YES"' in loader.conf. (Note that once this change is applied, /etc/defaults/loader.conf must also be updated, requiring an install world, not just an install kernel). 