### PR TITLE
Fix typos in the license

### DIFF
--- a/contrib/dlog/src/dl_kernel_segment.c
+++ b/contrib/dlog/src/dl_kernel_segment.c
@@ -13,8 +13,8 @@
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
- * ar	 met:
- *1. Redistributions of source code must retain the above copyright
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
  *    notice, this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the


### PR DESCRIPTION
Those were introduced in 48dab25ddb283edfcea8125131e9f884f51045e5.